### PR TITLE
ci: enable Renovate with auto-merge on green CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It should start on port 3000.
 
 ## Changelog
 
-- **2026-05-09** — Modernized the toolchain end-to-end: migrated from Create React App to Vite; replaced Redux Toolkit + Redux Saga with TanStack Query and React Router with file-based TanStack Router (filter/search/page state moved to typed URL params); type-checking moved to TypeScript Native Preview (`tsgo`). Bumped React and `react-dom` to v19 with the React Compiler enabled, `styled-components` to v6, and Prettier to v3. Pinned Node 24, switched to pnpm, and added Playwright e2e + Prettier `format:check` GitHub Actions running on every PR.
+- **2026-05-09** — Modernized the toolchain end-to-end: migrated from Create React App to Vite; replaced Redux Toolkit + Redux Saga with TanStack Query and React Router with file-based TanStack Router (filter/search/page state moved to typed URL params); type-checking moved to TypeScript Native Preview (`tsgo`). Bumped React and `react-dom` to v19 with the React Compiler enabled, `styled-components` to v6, and Prettier to v3. Pinned Node 24, switched to pnpm, and added Playwright e2e + Prettier `format:check` GitHub Actions running on every PR. Enabled Renovate with auto-merge on green CI (covering npm, GitHub Actions, and the Playwright container image in `e2e.yml` — bumped in lockstep with `@playwright/test`), and added a `main` branch ruleset requiring `chromium`, `prettier --check`, and `netlify/alledex/deploy-preview` to pass before merge.
 - **2023-01-31** — Migrated to pnpm and bumped all dependencies.
 - **2020-06-19** — Migrated state management to Redux and Redux Saga.
 - **2020-04-16** — Initial release.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "automerge": true,
+  "platformAutomerge": true,
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "groupName": "playwright"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` at repo root: weekly schedule, platform auto-merge, dependency dashboard.
- Groups `@playwright/test` (npm) with `mcr.microsoft.com/playwright` (the workflow `container:` image in `.github/workflows/e2e.yml`) into a single PR so they always bump in lockstep — Dependabot doesn't parse `container.image:` in workflows, which is why we're switching.
- Updates the 2026-05-09 README changelog entry.

## Follow-up (manual)
After this merges, install the Renovate GitHub App on the repo: https://github.com/apps/renovate. Renovate will detect the existing `renovate.json` and skip the onboarding PR.

## Test plan
- [ ] CI checks (`chromium`, `prettier --check`, `netlify/alledex/deploy-preview`) pass on this PR.
- [ ] After merge + app install: Renovate opens its first PR (likely an Actions or npm bump) and the `dependabot-auto-merge`-style behavior happens via `platformAutomerge: true` (PR sits with auto-merge enabled, GitHub merges once required checks pass).
- [ ] When `@playwright/test` next gets a bump, the PR also bumps the `mcr.microsoft.com/playwright:vX.Y.Z-noble` tag in `e2e.yml`.