### PR TITLE
ci: monitor PR bundle-size with compressed-size-action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,38 @@
+name: bundle-size
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bundle-size-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compressed-size:
+    name: gzip diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Compare compressed bundle size
+        uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: "./dist/assets/**/*.{js,css}"
+          exclude: "{**/*.map,**/node_modules/**}"
+          build-script: "build"
+          install-script: "pnpm install --frozen-lockfile"
+          # Vite emits `name-HASH.ext` — strip the 8-char content hash so
+          # the same logical file compares stably across base and head.
+          strip-hash: "-(\\w{8})\\."

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It should start on port 3000.
 
 ## Changelog
 
+- **2026-05-09** — Added a `bundle-size` GitHub Actions workflow using `preactjs/compressed-size-action` that posts a per-file gzip-size diff comment on every PR against `main` (informational, not required).
 - **2026-05-09** — Modernized the toolchain end-to-end: migrated from Create React App to Vite; replaced Redux Toolkit + Redux Saga with TanStack Query and React Router with file-based TanStack Router (filter/search/page state moved to typed URL params); type-checking moved to TypeScript Native Preview (`tsgo`). Bumped React and `react-dom` to v19 with the React Compiler enabled, `styled-components` to v6, and Prettier to v3. Pinned Node 24, switched to pnpm, and added Playwright e2e + Prettier `format:check` GitHub Actions running on every PR. Enabled Renovate with auto-merge on green CI (covering npm, GitHub Actions, and the Playwright container image in `e2e.yml` — bumped in lockstep with `@playwright/test`), and added a `main` branch ruleset requiring `chromium`, `prettier --check`, and `netlify/alledex/deploy-preview` to pass before merge.
 - **2023-01-31** — Migrated to pnpm and bumped all dependencies.
 - **2020-06-19** — Migrated state management to Redux and Redux Saga.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/bundle-size.yml` running `preactjs/compressed-size-action@v2` on every PR against `main`. The action builds both base and head, then posts/updates a single PR comment with a per-file gzip-size diff for `dist/assets/**/*.{js,css}`.
- Reuses the shared `./.github/actions/setup` composite (pnpm + Node 24 from `.nvmrc`) and overrides the install step to `pnpm install --frozen-lockfile`. `strip-hash` normalizes Vite's `name-HASH.ext` so files compare stably across builds.
- Informational only — not added to the `main` branch ruleset, so it does not gate merges. Useful as Renovate keeps auto-merging dep bumps that could silently grow the bundle.

## Test plan

- [ ] `bundle-size / gzip diff` job runs to completion on this PR
- [ ] Bot comment appears with a table of `dist/assets/*.js` files and (near-zero) gzip-size deltas vs `main`
- [ ] Pushing a follow-up commit updates the same comment in place rather than spamming new ones
- [ ] Existing required checks (`chromium`, `prettier --check`, `netlify/alledex/deploy-preview`) still pass