### PR TITLE
fix: satisfy jsx-a11y/prefer-tag-over-role on Height emoji

### DIFF
--- a/src/PokemonView/PokemonView.tsx
+++ b/src/PokemonView/PokemonView.tsx
@@ -86,9 +86,7 @@ export const PokemonView = () => {
             <div>
               <p className={heightText}>
                 Height:{" "}
-                <span role="img" aria-label={"Height"}>
-                  ↕️
-                </span>{" "}
+                <span aria-hidden="true">↕️</span>{" "}
                 {pokemon.height}
               </p>
             </div>

--- a/src/PokemonView/PokemonView.tsx
+++ b/src/PokemonView/PokemonView.tsx
@@ -85,9 +85,7 @@ export const PokemonView = () => {
             </div>
             <div>
               <p className={heightText}>
-                Height:{" "}
-                <span aria-hidden="true">↕️</span>{" "}
-                {pokemon.height}
+                Height: <span aria-hidden="true">↕️</span> {pokemon.height}
               </p>
             </div>
           </>


### PR DESCRIPTION
## Summary
- oxlint 1.64.0 (#57) enabled `jsx-a11y/prefer-tag-over-role`, which flagged the `<span role="img" aria-label="Height">` wrapping the ↕️ emoji in `PokemonView`.
- The preceding "Height:" text already names the value, so the emoji is purely decorative — switched to `aria-hidden="true"` and dropped the redundant `role` / `aria-label`. Screen readers no longer announce "Height" twice.

## Test plan
- [x] `pnpm lint` — 0 errors
- [ ] CI green (lint / typecheck / e2e / bundle-size)
- [ ] Visual: Height row still renders ↕️ next to the value